### PR TITLE
Feature/lib.eventing v0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 		<dependency>
 			<groupId>io.boomerang</groupId>
 			<artifactId>lib-eventing</artifactId>
-			<version>0.2.0</version>
+			<version>0.2.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,8 +62,8 @@
 		</dependency>
 		<dependency>
 			<groupId>io.boomerang</groupId>
-			<artifactId>lib-jetstream</artifactId>
-			<version>0.0.2</version>
+			<artifactId>lib-eventing</artifactId>
+			<version>0.2.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
@@ -149,7 +149,7 @@
 	<repositories>
 		<repository>
 			<id>github</id>
-			<url>https://maven.pkg.github.com/boomerang-io/flow.lib.streaming</url>
+			<url>https://maven.pkg.github.com/boomerang-io/*</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 		<dependency>
 			<groupId>io.boomerang</groupId>
 			<artifactId>lib-eventing</artifactId>
-			<version>0.2.1</version>
+			<version>0.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/src/main/java/io/boomerang/config/AttributeConfig.java
+++ b/src/main/java/io/boomerang/config/AttributeConfig.java
@@ -1,4 +1,4 @@
-package io.boomerang;
+package io.boomerang.config;
 
 import java.util.List;
 

--- a/src/main/java/io/boomerang/config/EventingConfig.java
+++ b/src/main/java/io/boomerang/config/EventingConfig.java
@@ -1,0 +1,74 @@
+package io.boomerang.config;
+
+import java.time.Duration;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import io.boomerang.eventing.nats.ConnectionPrimer;
+import io.boomerang.eventing.nats.jetstream.PubOnlyConfiguration;
+import io.boomerang.eventing.nats.jetstream.PubOnlyTunnel;
+import io.boomerang.eventing.nats.jetstream.PubTransmitter;
+import io.nats.client.Options;
+import io.nats.client.api.StorageType;
+import io.nats.client.api.StreamConfiguration;
+
+@Configuration
+public class EventingConfig {
+
+  private ConnectionPrimer connectionPrimer;
+
+  @Value("#{'${eventing.nats.server.urls}'.split(',')}")
+  private List<String> serverUrls;
+
+  @Value("${eventing.nats.server.reconnect-wait-time:PT10S}")
+  private Duration serverReconnectWaitTime;
+
+  @Value("${eventing.nats.server.reconnect-max-attempts:-1}")
+  private Integer serverReconnectMaxAttempts;
+
+  @Value("${eventing.jetstream.stream.name}")
+  private String jetstreamStreamName;
+
+  @Value("${eventing.jetstream.stream.storage-type}")
+  private StorageType jetstreamStreamStorageType;
+
+  @Value("${eventing.jetstream.stream.subject}")
+  private String jetstreamStreamSubject;
+
+  @Bean
+  @ConditionalOnProperty(value = "eventing.enabled", havingValue = "true", matchIfMissing = false)
+  public PubOnlyTunnel pubOnlyTunnel() {
+
+    // @formatter:off
+    StreamConfiguration streamConfiguration = new StreamConfiguration.Builder()
+        .name(jetstreamStreamName)
+        .storageType(jetstreamStreamStorageType)
+        .subjects(jetstreamStreamSubject)
+        .build();
+    PubOnlyConfiguration pubOnlyConfiguration = new PubOnlyConfiguration.Builder()
+        .automaticallyCreateStream(true)
+        .build();
+    // @formatter:on
+
+    return new PubTransmitter(getConnectionPrimer(), streamConfiguration, pubOnlyConfiguration);
+  }
+
+  private ConnectionPrimer getConnectionPrimer() {
+
+    if (connectionPrimer == null) {
+
+      // @formatter:off
+      Options.Builder optionsBuilder = new Options.Builder()
+          .servers(serverUrls.toArray(new String[0]))
+          .reconnectWait(serverReconnectWaitTime)
+          .maxReconnects(serverReconnectMaxAttempts);
+      // @formatter:on
+
+      connectionPrimer = new ConnectionPrimer(optionsBuilder);
+    }
+
+    return connectionPrimer;
+  }
+}

--- a/src/main/java/io/boomerang/config/EventingConfig.java
+++ b/src/main/java/io/boomerang/config/EventingConfig.java
@@ -15,6 +15,7 @@ import io.nats.client.api.StorageType;
 import io.nats.client.api.StreamConfiguration;
 
 @Configuration
+@ConditionalOnProperty(value = "eventing.enabled", havingValue = "true", matchIfMissing = false)
 public class EventingConfig {
 
   private ConnectionPrimer connectionPrimer;
@@ -38,7 +39,6 @@ public class EventingConfig {
   private String jetstreamStreamSubject;
 
   @Bean
-  @ConditionalOnProperty(value = "eventing.enabled", havingValue = "true", matchIfMissing = false)
   public PubOnlyTunnel pubOnlyTunnel() {
 
     // @formatter:off

--- a/src/main/java/io/boomerang/service/EventProcessorImpl.java
+++ b/src/main/java/io/boomerang/service/EventProcessorImpl.java
@@ -31,7 +31,7 @@ public class EventProcessorImpl implements EventProcessor {
   @Value("${eventing.auth.enabled:false}")
   private Boolean authorizationEnabled;
 
-  @Value("${eventing.jetstream.stream.subject}")
+  @Value("${eventing.jetstream.stream.subject:#{null}}")
   private String jetstreamStreamSubject;
 
   @Autowired(required = false)

--- a/src/main/java/io/boomerang/service/EventProcessorImpl.java
+++ b/src/main/java/io/boomerang/service/EventProcessorImpl.java
@@ -28,7 +28,7 @@ public class EventProcessorImpl implements EventProcessor {
 
   private static final String TYPE_PREFIX = "io.boomerang.eventing.";
 
-  @Value("${eventing.auth.enabled}")
+  @Value("${eventing.auth.enabled:false}")
   private Boolean authorizationEnabled;
 
   @Value("${eventing.jetstream.stream.subject}")

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,9 +1,9 @@
 
 # Eventing properties (NATS Jetstream)
+eventing.enabled=false
 eventing.auth.enabled=false
-eventing.jetstream.enabled=false
-eventing.jetstream.server.url=nats://localhost:4222
-eventing.jetstream.server.reconnect-wait-time=PT30S
+eventing.nats.server.urls=nats://localhost:4222
+eventing.nats.server.reconnect-wait-time=PT30S
 
 # Workflow service properties
 workflow.service.host=localhost:8080

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,20 +16,15 @@ boomerang.environment=
 management.endpoints.web.base-path=/
 
 # Eventing properties (NATS Jetstream)
+eventing.enabled=true
 eventing.auth.enabled=true
-
-eventing.jetstream.enabled=true
-eventing.jetstream.server.url=nats://localhost:4222
-eventing.jetstream.server.reconnect-wait-time=PT10S
-eventing.jetstream.server.reconnect-max-attempts=-1
+eventing.nats.server.urls=nats://localhost:4222
+eventing.nats.server.reconnect-wait-time=PT10S
+eventing.nats.server.reconnect-max-attempts=-1
 
 eventing.jetstream.stream.name=flow-event-stream
 eventing.jetstream.stream.storage-type=File
 eventing.jetstream.stream.subject=flow.event.cloudevent
-
-eventing.jetstream.consumer.pull.name=flow-event-pull-consumer
-eventing.jetstream.consumer.push.name=flow-event-push-consumer
-eventing.jetstream.consumer.push.delivery-subject=out.flow.event
 
 # Workflow service properties
 workflow.service.host=


### PR DESCRIPTION
Closes #15 

This PR upgrades eventing integration for Flow to the latest eventing library version `0.2` (version `0.2.2`).

#### Changelog

**New**

- `lib.eventing:0.2.2`
- Improved stability.
- Support for multiple streams and consumers.
- `EventingConfig` which instantiates a `PubOnlyTunnel` bean for pushing messages to NATS Jetstream.

**Changed**

- If `eventing.enabled` property in `application.properties` is set to `false`, other eventing-related properties are not required in the file (and does not crash the service from launching itself if these properties are omitted completely from the file).

**Removed**

- Old Jetstream client and any related classes, objects and files (clean-up).

#### Testing / Reviewing

The service was tested e2e with the deployed NATS server in DEV OCP2. The `flow.service.listener`  was running locally and connected to remote NATS server. The `flow.service.workflow` was also running locally, but connected to all the required components remotely (i. e. `bmrg-core-services-users`, `bmrg-flow-services-controller`, `bmrg-dev-mdb001-mongodb` and `bmrg-dev-nats`). All tests were executed by launching a custom-defined workflow through Cloud Events:

- CE -> `service.listener` -> NATS Jetstream <-> `service.workflow` -> execute workflow

#### Note

This PR goes hand in hand with:

- boomerang-io/charts#46
- boomerang-io/flow.service.workflow#126