### PR TITLE
Upgrade `lib.eventing`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 		<dependency>
 			<groupId>io.boomerang</groupId>
 			<artifactId>lib-eventing</artifactId>
-			<version>0.2.2</version>
+			<version>0.2.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
#### Changelog

**Changed**

- Maven eventing library upgraded to `0.2.5`.