### PR TITLE
UPdated jdk docker image to resolve twistlock vulnerabilty(BinUtils)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
 FROM eclipse-temurin:17-jdk-alpine
+
+RUN apk update && \
+    apk upgrade --no-cache binutils
+    
 ENV JAVA_OPTS=""
 ENV BMRG_HOME=/opt/boomerang
 ENV BMRG_SVC=service-listener


### PR DESCRIPTION
Closes #

{{short description}}
Updated binutils component in jdk 17 docker image to fix vulnerability
#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
